### PR TITLE
Use run number generated by harvester when determining what files to process

### DIFF
--- a/iDeletedFileList/src/main/component/iDeletedFileList_begin.javajet
+++ b/iDeletedFileList/src/main/component/iDeletedFileList_begin.javajet
@@ -1,35 +1,17 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.core.model.process.ElementParameterParser
-		org.talend.core.model.metadata.IMetadataTable
-		org.talend.core.model.metadata.IMetadataColumn
-		org.talend.core.model.process.IConnection
-		org.talend.core.model.process.IConnectionCategory
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.metadata.types.JavaTypesManager
-		org.talend.core.model.metadata.types.JavaType
-		java.util.List
-		java.util.Map
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
+	<%@ include file="../templates/Resources/ComponentBeginStart.javajet"%>
+
+	Long runNo_<%=cid%> = au.org.emii.talend.JobRunNos.getRunNo(<%=jobName%>);
 
 	String dbquery_<%=cid%> = ""
 		+ " select indexed_file.id, indexed_file.url, indexed_file.modified"
 		+ "   from indexed_file "
 		+ "   join index_job "
 		+ "     on indexed_file.job_id = index_job.id "
-		+ "    and indexed_file.last_indexed_run = index_job.last_run_no " 
 		+ "   join file_harvest on (file_harvest.file_id = indexed_file.id)"
-		+ " where indexed_file.deleted"
-		+ "   and file_harvest.last_change_type <> 'deleted'"
+		+ " where indexed_file.last_indexed_run = " + runNo_<%=cid%>.toString()
+		+ "   and indexed_file.deleted"
 		+ "   and index_job.name = ?"
 		+ "   and file_harvest.harvest_type = ?"
 	;
 
-	<%@ include file="../templates/Resources/ComponentBegin.javajet"%>
+	<%@ include file="../templates/Resources/ComponentBeginFinish.javajet"%>

--- a/iDeletedFileList/src/main/component/iDeletedFileList_end.javajet
+++ b/iDeletedFileList/src/main/component/iDeletedFileList_end.javajet
@@ -1,23 +1,10 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.process.ElementParameterParser
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
 	<%@ include file="../templates/Resources/ComponentEndStart.javajet"%>
-
 
 	String update_<%=cid%> = ""
 		+ " update file_harvest"
 		+ " set last_moddate_harvested = ?,"
 		+ "   last_change_type = 'deleted',"
-		+ "   last_change_run = (select last_run_no from index_job where name = ?)"
+		+ "   last_change_run = ?"
 		+ " where harvest_type = ?"
 		+ " and file_id = ?"
 	;
@@ -26,7 +13,7 @@
 		.prepareStatement(update_<%=cid%>);
 
 	pstmt_<%=cid%>.setTimestamp(1, new java.sql.Timestamp(lastModified_<%=cid%>.getTime()));
-	pstmt_<%=cid%>.setString(2, jobName_<%=cid%>);
+	pstmt_<%=cid%>.setLong(2, runNo_<%=cid%>);
 	pstmt_<%=cid%>.setString(3, harvestType_<%=cid%>);
 	pstmt_<%=cid%>.setLong(4, id_<%=cid%>);
 

--- a/iDeletedFileList/src/main/component/iDeletedFileList_java.xml
+++ b/iDeletedFileList/src/main/component/iDeletedFileList_java.xml
@@ -83,7 +83,8 @@
   <CODEGENERATION> 
     <IMPORTS> 
 	  <IMPORT NAME="Driver-Postgres" MODULE="postgresql-8.3-603.jdbc3.jar" REQUIRED="true" />
-    </IMPORTS> 
+      <IMPORT MODULE="iUpdateIndex-1.0.0-SNAPSHOT.jar" NAME="iUpdateIndex-1.0.0-SNAPSHOT" REQUIRED="true"/>
+    </IMPORTS>
   </CODEGENERATION>  
   <RETURNS> 
     <RETURN AVAILABILITY="FLOW" NAME="FILE_ID" TYPE="id_Long"/> 

--- a/iDeletedResources/src/main/component/iDeletedResources_begin.javajet
+++ b/iDeletedResources/src/main/component/iDeletedResources_begin.javajet
@@ -1,23 +1,4 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.core.model.process.ElementParameterParser
-		org.talend.core.model.metadata.IMetadataTable
-		org.talend.core.model.metadata.IMetadataColumn
-		org.talend.core.model.process.IConnection
-		org.talend.core.model.process.IConnectionCategory
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.metadata.types.JavaTypesManager
-		org.talend.core.model.metadata.types.JavaType
-		java.util.List
-		java.util.Map
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
+	<%@ include file="../templates/Resources/ComponentBeginStart.javajet"%>
 
 	String dbquery_<%=cid%> = ""
 		+ " select indexed_file.id, indexed_file.url, indexed_file.modified"
@@ -30,4 +11,4 @@
 		+ "   and file_harvest.harvest_type = ?"
 	;
 
-	<%@ include file="../templates/Resources/ComponentBegin.javajet"%>
+	<%@ include file="../templates/Resources/ComponentBeginFinish.javajet"%>

--- a/iDeletedResources/src/main/component/iDeletedResources_end.javajet
+++ b/iDeletedResources/src/main/component/iDeletedResources_end.javajet
@@ -1,17 +1,4 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.process.ElementParameterParser
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
 	<%@ include file="../templates/Resources/ComponentEndStart.javajet"%>
-
 
 	String update_<%=cid%> = ""
 		+ " update file_harvest"

--- a/iHarvestResources/src/main/component/iHarvestResources_begin.javajet
+++ b/iHarvestResources/src/main/component/iHarvestResources_begin.javajet
@@ -1,23 +1,4 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.core.model.process.ElementParameterParser
-		org.talend.core.model.metadata.IMetadataTable
-		org.talend.core.model.metadata.IMetadataColumn
-		org.talend.core.model.process.IConnection
-		org.talend.core.model.process.IConnectionCategory
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.metadata.types.JavaTypesManager
-		org.talend.core.model.metadata.types.JavaType
-		java.util.List
-		java.util.Map
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
+	<%@ include file="../templates/Resources/ComponentBeginStart.javajet"%>
 
 	String dbquery_<%=cid%> =
 		"select indexed_file.id, indexed_file.url, indexed_file.modified " +
@@ -34,4 +15,4 @@
 		"    or  file_harvest.last_moddate_harvested is null) "
 	;
 
-	<%@ include file="../templates/Resources/ComponentBegin.javajet"%>
+	<%@ include file="../templates/Resources/ComponentBeginFinish.javajet"%>

--- a/iHarvestResources/src/main/component/iHarvestResources_end.javajet
+++ b/iHarvestResources/src/main/component/iHarvestResources_end.javajet
@@ -1,16 +1,3 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.process.ElementParameterParser
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-
-%>
 	<%@ include file="../templates/Resources/ComponentEndStart.javajet"%>
 
 	String insert_<%=cid%> = ""

--- a/iModifiedFileList/src/main/component/iModifiedFileList_begin.javajet
+++ b/iModifiedFileList/src/main/component/iModifiedFileList_begin.javajet
@@ -1,24 +1,6 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.core.model.process.ElementParameterParser
-		org.talend.core.model.metadata.IMetadataTable
-		org.talend.core.model.metadata.IMetadataColumn
-		org.talend.core.model.process.IConnection
-		org.talend.core.model.process.IConnectionCategory
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.metadata.types.JavaTypesManager
-		org.talend.core.model.metadata.types.JavaType
-		java.util.List
-		java.util.Map
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
+	<%@ include file="../templates/Resources/ComponentBeginStart.javajet"%>
 
+	Long runNo_<%=cid%> = au.org.emii.talend.JobRunNos.getRunNo(<%=jobName%>);
 
 	String dbquery_<%=cid%> = ""
 		+ " select indexed_file.id, indexed_file.url, indexed_file.modified"
@@ -28,11 +10,10 @@
 		+ "   and file_harvest.last_change_type <> 'deleted' "
 		+ "  join index_job "
 		+ "    on index_job.id = indexed_file.job_id "
-		+ "   and indexed_file.last_indexed_run = index_job.last_run_no " 
-		+ " where file_harvest.last_change_run <> indexed_file.last_indexed_run"
+		+ " where indexed_file.last_indexed_run = " + runNo_<%=cid%>.toString()
 		+ "   and not indexed_file.deleted"
 		+ "   and index_job.name = ? "
 		+ "   and harvest_type = ? "
 	;
 
-	<%@ include file="../templates/Resources/ComponentBegin.javajet"%>
+	<%@ include file="../templates/Resources/ComponentBeginFinish.javajet"%>

--- a/iModifiedFileList/src/main/component/iModifiedFileList_end.javajet
+++ b/iModifiedFileList/src/main/component/iModifiedFileList_end.javajet
@@ -1,23 +1,10 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.process.ElementParameterParser
-	"
-%>
-<%
-    CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-    INode node = (INode)codeGenArgument.getArgument();
-    String cid = node.getUniqueName();
-%>
-
 	<%@ include file="../templates/Resources/ComponentEndStart.javajet"%>
 
 	String update_<%=cid%> = ""
 		+ " update file_harvest "
 		+ "   set last_moddate_harvested = ?,"
 		+ "   last_change_type = 'modified',"
-		+ "   last_change_run = (select last_run_no from index_job where name = ?)"
+		+ "   last_change_run = ?"
 		+ " where harvest_type = ?"
 		+ " and file_id = ?"
 	;
@@ -26,7 +13,7 @@
 		.prepareStatement(update_<%=cid%>);
 
 	pstmt_<%=cid%>.setTimestamp(1, new java.sql.Timestamp(lastModified_<%=cid%>.getTime()));
-	pstmt_<%=cid%>.setString(2, jobName_<%=cid%>);
+	pstmt_<%=cid%>.setLong(2, runNo_<%=cid%>);
 	pstmt_<%=cid%>.setString(3, harvestType_<%=cid%>);
 	pstmt_<%=cid%>.setLong(4, id_<%=cid%>);
 

--- a/iModifiedFileList/src/main/component/iModifiedFileList_java.xml
+++ b/iModifiedFileList/src/main/component/iModifiedFileList_java.xml
@@ -85,7 +85,8 @@
   <CODEGENERATION> 
     <IMPORTS> 
 	  <IMPORT NAME="Driver-Postgres" MODULE="postgresql-8.3-603.jdbc3.jar" REQUIRED="true" />
-    </IMPORTS> 
+      <IMPORT MODULE="iUpdateIndex-1.0.0-SNAPSHOT.jar" NAME="iUpdateIndex-1.0.0-SNAPSHOT" REQUIRED="true"/>
+    </IMPORTS>
   </CODEGENERATION>  
   <RETURNS> 
     <RETURN AVAILABILITY="FLOW" NAME="FILE_ID" TYPE="id_Long"/> 

--- a/iModifiedResources/src/main/component/iModifiedResources_begin.javajet
+++ b/iModifiedResources/src/main/component/iModifiedResources_begin.javajet
@@ -1,24 +1,4 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.core.model.process.ElementParameterParser
-		org.talend.core.model.metadata.IMetadataTable
-		org.talend.core.model.metadata.IMetadataColumn
-		org.talend.core.model.process.IConnection
-		org.talend.core.model.process.IConnectionCategory
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.metadata.types.JavaTypesManager
-		org.talend.core.model.metadata.types.JavaType
-		java.util.List
-		java.util.Map
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
-
+	<%@ include file="../templates/Resources/ComponentBeginStart.javajet"%>
 
 	String dbquery_<%=cid%> = ""
 		+ " select indexed_file.id, indexed_file.url, indexed_file.modified"
@@ -31,4 +11,4 @@
 		+ "   and harvest_type = ? "
 	;
 
-	<%@ include file="../templates/Resources/ComponentBegin.javajet"%>
+	<%@ include file="../templates/Resources/ComponentBeginFinish.javajet"%>

--- a/iModifiedResources/src/main/component/iModifiedResources_end.javajet
+++ b/iModifiedResources/src/main/component/iModifiedResources_end.javajet
@@ -1,16 +1,3 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.process.ElementParameterParser
-	"
-%>
-<%
-    CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-    INode node = (INode)codeGenArgument.getArgument();
-    String cid = node.getUniqueName();
-%>
-
 	<%@ include file="../templates/Resources/ComponentEndStart.javajet"%>
 
 	String update_<%=cid%> = ""

--- a/iNewFileList/src/main/component/iNewFileList_begin.javajet
+++ b/iNewFileList/src/main/component/iNewFileList_begin.javajet
@@ -1,37 +1,20 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.core.model.process.ElementParameterParser
-		org.talend.core.model.metadata.IMetadataTable
-		org.talend.core.model.metadata.IMetadataColumn
-		org.talend.core.model.process.IConnection
-		org.talend.core.model.process.IConnectionCategory
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.metadata.types.JavaTypesManager
-		org.talend.core.model.metadata.types.JavaType
-		java.util.List
-		java.util.Map
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
+	<%@ include file="../templates/Resources/ComponentBeginStart.javajet"%>
+
+	Long runNo_<%=cid%> = au.org.emii.talend.JobRunNos.getRunNo(<%=jobName%>);
 
 	String dbquery_<%=cid%> =
 		"select indexed_file.id, indexed_file.url, indexed_file.modified " +
 		"  from indexed_file " +
 		"  join index_job " +
 		"    on indexed_file.job_id = index_job.id " +
-		"   and indexed_file.last_indexed_run = index_job.last_run_no " +
 		"   and index_job.name = ? " +
 		"  left join file_harvest " +
 		"    on file_harvest.file_id = indexed_file.id " +
 		"   and file_harvest.harvest_type = ? " +
 		"   and file_harvest.last_change_type <> 'deleted' " +
-		" where file_harvest.last_change_run is null " +
+		" where indexed_file.last_indexed_run = " + runNo_<%=cid%>.toString() +
+		"   and file_harvest.last_change_run is null " +
 		"   and not indexed_file.deleted "
 	;
 
-	<%@ include file="../templates/Resources/ComponentBegin.javajet"%>
+	<%@ include file="../templates/Resources/ComponentBeginFinish.javajet"%>

--- a/iNewFileList/src/main/component/iNewFileList_end.javajet
+++ b/iNewFileList/src/main/component/iNewFileList_end.javajet
@@ -1,21 +1,8 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.process.ElementParameterParser
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
 	<%@ include file="../templates/Resources/ComponentEndStart.javajet"%>
-
 
 	String insert_<%=cid%> = ""
 		+ " with new_data( file_id, harvest_type, last_moddate_harvested, last_change_run )"
-		+ "   as ( values( ?, ?, ?::timestamptz, (select last_run_no from index_job where name = ? ) )"
+		+ "   as ( values( ?, ?, ?::timestamptz, ? )"
 		+ " ),"
 		+ " updated as ("
 		+ "   update file_harvest set last_change_type = 'readded',"
@@ -40,7 +27,7 @@
 	pstmt_<%=cid%>.setLong(1, id_<%=cid%>);
 	pstmt_<%=cid%>.setString(2, harvestType_<%=cid%>);
 	pstmt_<%=cid%>.setTimestamp(3, new java.sql.Timestamp(lastModified_<%=cid%>.getTime()));
-	pstmt_<%=cid%>.setString(4, jobName_<%=cid%>);
+	pstmt_<%=cid%>.setLong(4, runNo_<%=cid%>);
 
 	System.out.format( "* <%=cid%> new/readded resource file_id=%d\n", id_<%=cid%> );
 

--- a/iNewFileList/src/main/component/iNewFileList_java.xml
+++ b/iNewFileList/src/main/component/iNewFileList_java.xml
@@ -85,7 +85,8 @@
   <CODEGENERATION> 
     <IMPORTS> 
 	  <IMPORT NAME="Driver-Postgres" MODULE="postgresql-8.3-603.jdbc3.jar" REQUIRED="true" />
-    </IMPORTS> 
+      <IMPORT MODULE="iUpdateIndex-1.0.0-SNAPSHOT.jar" NAME="iUpdateIndex-1.0.0-SNAPSHOT" REQUIRED="true"/>
+    </IMPORTS>
   </CODEGENERATION>  
   <RETURNS> 
     <RETURN AVAILABILITY="FLOW" NAME="FILE_ID" TYPE="id_Long"/> 

--- a/iNewOrModifiedFileList/src/main/component/iNewOrModifiedFileList_begin.javajet
+++ b/iNewOrModifiedFileList/src/main/component/iNewOrModifiedFileList_begin.javajet
@@ -1,30 +1,13 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.core.model.process.ElementParameterParser
-		org.talend.core.model.metadata.IMetadataTable
-		org.talend.core.model.metadata.IMetadataColumn
-		org.talend.core.model.process.IConnection
-		org.talend.core.model.process.IConnectionCategory
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.metadata.types.JavaTypesManager
-		org.talend.core.model.metadata.types.JavaType
-		java.util.List
-		java.util.Map
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
+	<%@ include file="../templates/Resources/ComponentBeginStart.javajet"%>
+
+	Long runNo_<%=cid%> = au.org.emii.talend.JobRunNos.getRunNo(<%=jobName%>);
 
 	String dbquery_<%=cid%> =
 		"select indexed_file.id, indexed_file.url, indexed_file.modified " +
 		"  from indexed_file " +
 		"  join index_job " +
 		"    on indexed_file.job_id = index_job.id " +
-		"   and indexed_file.last_indexed_run = index_job.last_run_no " +
+		"   and indexed_file.last_indexed_run = " + runNo_<%=cid%>.toString() +
 		"   and index_job.name = ? " +
 		"  left join file_harvest " +
 		"    on file_harvest.file_id = indexed_file.id " +
@@ -33,4 +16,4 @@
 		" where not indexed_file.deleted "
 	;
 
-	<%@ include file="../templates/Resources/ComponentBegin.javajet"%>
+	<%@ include file="../templates/Resources/ComponentBeginFinish.javajet"%>

--- a/iNewOrModifiedFileList/src/main/component/iNewOrModifiedFileList_end.javajet
+++ b/iNewOrModifiedFileList/src/main/component/iNewOrModifiedFileList_end.javajet
@@ -1,21 +1,8 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.process.ElementParameterParser
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-
-%>
 	<%@ include file="../templates/Resources/ComponentEndStart.javajet"%>
 
 	String insert_<%=cid%> = ""
 	+ " with new_data( file_id, harvest_type, last_moddate_harvested, last_change_run )"
-	+ "   as ( values( ?, ?, ?::timestamptz, (select last_run_no from index_job where name = ? ) ) ),"
+	+ "   as ( values( ?, ?, ?::timestamptz, ? ) ),"
 	+ " updated as ("
 	+ "   update file_harvest set last_change_type = 'modified',"
 	+ "     last_change_run = (select last_change_run from new_data),"
@@ -40,7 +27,7 @@
 	pstmt_<%=cid%>.setLong(1, id_<%=cid%>);
 	pstmt_<%=cid%>.setString(2, harvestType_<%=cid%>);
 	pstmt_<%=cid%>.setTimestamp(3, new java.sql.Timestamp(lastModified_<%=cid%>.getTime()));
-	pstmt_<%=cid%>.setString(4, jobName_<%=cid%>);
+	pstmt_<%=cid%>.setLong(4, runNo_<%=cid%>);
 
 	System.out.format( "* <%=cid%> modified/new resource file_id=%d\n", id_<%=cid%> );
 

--- a/iNewOrModifiedFileList/src/main/component/iNewOrModifiedFileList_java.xml
+++ b/iNewOrModifiedFileList/src/main/component/iNewOrModifiedFileList_java.xml
@@ -84,7 +84,8 @@
   <CODEGENERATION> 
     <IMPORTS> 
       <IMPORT NAME="Driver-Postgres" MODULE="postgresql-8.3-603.jdbc3.jar" REQUIRED="true" />
-    </IMPORTS> 
+      <IMPORT MODULE="iUpdateIndex-1.0.0-SNAPSHOT.jar" NAME="iUpdateIndex-1.0.0-SNAPSHOT" REQUIRED="true"/>
+    </IMPORTS>
   </CODEGENERATION>  
   <RETURNS> 
     <RETURN AVAILABILITY="FLOW" NAME="FILE_ID" TYPE="id_Long"/> 

--- a/iNewResources/src/main/component/iNewResources_begin.javajet
+++ b/iNewResources/src/main/component/iNewResources_begin.javajet
@@ -1,23 +1,4 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.core.model.process.ElementParameterParser
-		org.talend.core.model.metadata.IMetadataTable
-		org.talend.core.model.metadata.IMetadataColumn
-		org.talend.core.model.process.IConnection
-		org.talend.core.model.process.IConnectionCategory
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.metadata.types.JavaTypesManager
-		org.talend.core.model.metadata.types.JavaType
-		java.util.List
-		java.util.Map
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
+	<%@ include file="../templates/Resources/ComponentBeginStart.javajet"%>
 
 	String dbquery_<%=cid%> =
 		"select indexed_file.id, indexed_file.url, indexed_file.modified " +
@@ -33,5 +14,4 @@
 		" where file_harvest.last_moddate_harvested is null "
 	;
 
-
-	<%@ include file="../templates/Resources/ComponentBegin.javajet"%>
+	<%@ include file="../templates/Resources/ComponentBeginFinish.javajet"%>

--- a/iNewResources/src/main/component/iNewResources_end.javajet
+++ b/iNewResources/src/main/component/iNewResources_end.javajet
@@ -1,17 +1,4 @@
-<%@ jet
-	imports="
-		org.talend.core.model.process.INode
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.process.ElementParameterParser
-	"
-%>
-<%
-	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
-	INode node = (INode)codeGenArgument.getArgument();
-	String cid = node.getUniqueName();
-%>
 	<%@ include file="../templates/Resources/ComponentEndStart.javajet"%>
-
 
 	String insert_<%=cid%> = ""
 		+ " with new_data( file_id, harvest_type, last_moddate_harvested, last_change_run )"

--- a/iUpdateIndex/src/main/java/au/org/emii/talend/JobRunNos.java
+++ b/iUpdateIndex/src/main/java/au/org/emii/talend/JobRunNos.java
@@ -1,0 +1,24 @@
+package au.org.emii.talend;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/* A list of the last run numbers used for indexing jobs run by this harvester  */
+
+public class JobRunNos {
+    static private Map<String, Long> jobRunNos = new ConcurrentHashMap<String, Long>();
+
+    static public void setRunNo(String jobName, Long runNo) {
+        jobRunNos.put(jobName, runNo);
+    }
+
+    static public Long getRunNo(String jobName) {
+        Long runNo = jobRunNos.get(jobName);
+
+        if (runNo == null) {
+            throw new RuntimeException("No run number recorded for '" + jobName + "' indexing job");
+        }
+
+        return runNo;
+    }
+}

--- a/iUpdateIndex/src/main/java/au/org/emii/talend/updateindex/FileIndexUpdater.java
+++ b/iUpdateIndex/src/main/java/au/org/emii/talend/updateindex/FileIndexUpdater.java
@@ -8,6 +8,7 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.Date;
 
+import au.org.emii.talend.JobRunNos;
 import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
@@ -163,6 +164,10 @@ public class FileIndexUpdater {
             rs.next();
             jobId = rs.getLong("id");
             runNo = rs.getLong("last_run_no");
+
+            // publish run number used for this indexing job
+            JobRunNos.setRunNo(jobName, runNo);
+
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/templates/src/main/templates/Resources/ComponentBeginFinish.javajet
+++ b/templates/src/main/templates/Resources/ComponentBeginFinish.javajet
@@ -1,38 +1,3 @@
-<%@ jet 
-	imports="
-		org.talend.core.model.process.INode 
-		org.talend.core.model.process.ElementParameterParser 
-		org.talend.core.model.metadata.IMetadataTable 
-		org.talend.core.model.metadata.IMetadataColumn 
-		org.talend.core.model.process.IConnection
-		org.talend.core.model.process.IConnectionCategory
-		org.talend.designer.codegen.config.CodeGeneratorArgument
-		org.talend.core.model.metadata.types.JavaTypesManager
-		org.talend.core.model.metadata.types.JavaType
-		java.util.List 
-    	java.util.Map		
-	" 
-%>
-<%
-    String dbhost = ElementParameterParser.getValue(node, "__HOST__");
-    String dbport = ElementParameterParser.getValue(node, "__PORT__");
-    String dbschema = ElementParameterParser.getValue(node, "__SCHEMA_DB__");
-    String dbname = ElementParameterParser.getValue(node, "__DBNAME__");
-    String dbuser = ElementParameterParser.getValue(node, "__USER__");
-    String dbpass = ElementParameterParser.getValue(node, "__PASS__");
-    
-    String jobName = ElementParameterParser.getValue(node, "__JOBNAME__");
-    String harvestType = ElementParameterParser.getValue(node, "__HARVEST_TYPE__");
-
-    boolean useFilter = ElementParameterParser.getValue(node, "__USE_FILTER__").equalsIgnoreCase("true");
-    String filter = ElementParameterParser.getValue(node, "__FILTER__");
-    
-    boolean useCustomQuery = ElementParameterParser.getValue(node, "__USE_CUSTOM_QUERY__").equalsIgnoreCase("true");
-    String customQuery = ElementParameterParser.getValue(node, "__CUSTOM_QUERY__");
-
-    String dieOnErrorValue = ElementParameterParser.getValue(node, "__DIE_ON_ERROR__");
-    boolean dieOnError = dieOnErrorValue != null && dieOnErrorValue.equalsIgnoreCase("true");
-%>
 
 	int nb_resources_<%=cid %> = 0;
 	

--- a/templates/src/main/templates/Resources/ComponentBeginStart.javajet
+++ b/templates/src/main/templates/Resources/ComponentBeginStart.javajet
@@ -1,0 +1,36 @@
+<%@ jet
+	imports="
+		org.talend.core.model.process.INode
+		org.talend.core.model.process.ElementParameterParser
+		org.talend.core.model.metadata.IMetadataTable
+		org.talend.core.model.metadata.IMetadataColumn
+		org.talend.core.model.process.IConnection
+		org.talend.core.model.process.IConnectionCategory
+		org.talend.designer.codegen.config.CodeGeneratorArgument
+	"
+%>
+<%
+	CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
+	INode node = (INode)codeGenArgument.getArgument();
+	String cid = node.getUniqueName();
+
+    String dbhost = ElementParameterParser.getValue(node, "__HOST__");
+    String dbport = ElementParameterParser.getValue(node, "__PORT__");
+    String dbschema = ElementParameterParser.getValue(node, "__SCHEMA_DB__");
+    String dbname = ElementParameterParser.getValue(node, "__DBNAME__");
+    String dbuser = ElementParameterParser.getValue(node, "__USER__");
+    String dbpass = ElementParameterParser.getValue(node, "__PASS__");
+    
+    String jobName = ElementParameterParser.getValue(node, "__JOBNAME__");
+    String harvestType = ElementParameterParser.getValue(node, "__HARVEST_TYPE__");
+
+    boolean useFilter = ElementParameterParser.getValue(node, "__USE_FILTER__").equalsIgnoreCase("true");
+    String filter = ElementParameterParser.getValue(node, "__FILTER__");
+    
+    boolean useCustomQuery = ElementParameterParser.getValue(node, "__USE_CUSTOM_QUERY__").equalsIgnoreCase("true");
+    String customQuery = ElementParameterParser.getValue(node, "__CUSTOM_QUERY__");
+
+    String dieOnErrorValue = ElementParameterParser.getValue(node, "__DIE_ON_ERROR__");
+    boolean dieOnError = dieOnErrorValue != null && dieOnErrorValue.equalsIgnoreCase("true");
+%>
+

--- a/templates/src/main/templates/Resources/ComponentEndFinish.javajet
+++ b/templates/src/main/templates/Resources/ComponentEndFinish.javajet
@@ -1,7 +1,3 @@
-<%
-    String dieOnErrorValue = ElementParameterParser.getValue(node, "__DIE_ON_ERROR__");
-    boolean dieOnError = dieOnErrorValue != null && dieOnErrorValue.equalsIgnoreCase("true");
-%>
 
                 pstmt_<%=cid%>.executeUpdate();
                                             

--- a/templates/src/main/templates/Resources/ComponentEndStart.javajet
+++ b/templates/src/main/templates/Resources/ComponentEndStart.javajet
@@ -1,0 +1,15 @@
+<%@ jet
+    imports="
+        org.talend.core.model.process.INode
+        org.talend.designer.codegen.config.CodeGeneratorArgument
+        org.talend.core.model.process.ElementParameterParser
+    "
+%>
+<%
+    CodeGeneratorArgument codeGenArgument = (CodeGeneratorArgument) argument;
+    INode node = (INode)codeGenArgument.getArgument();
+    String cid = node.getUniqueName();
+
+    String dieOnErrorValue = ElementParameterParser.getValue(node, "__DIE_ON_ERROR__");
+    boolean dieOnError = dieOnErrorValue != null && dieOnErrorValue.equalsIgnoreCase("true");
+%>


### PR DESCRIPTION
The harvesting components were using the last_run_no from index_job to lookup files that needed to be processed which caused problems when more than one invocation of the harvester could be run  at once (i.e. the generic_timestep harvester).   Instead record the run_number generated by the harvester in a global map and use it when looking for files that need to be processed so the right ones are selected.

Moved common javajet code to harvesting component templates to reduce duplication.

Resolves the issue locally for me.

