### PR TITLE
Remove bumpversion from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,18 +6,6 @@ pipeline {
         }
     }
     stages {
-        stage('set_version_build') {
-            when { not { branch "master" } }
-            steps {
-                sh './bumpversion.sh build'
-            }
-        }
-        stage('set_version_release') {
-            when { branch "master" }
-            steps {
-                sh './bumpversion.sh release'
-            }
-        }
         stage('package') {
             steps {
                 sh 'mvn clean test install'


### PR DESCRIPTION
There are several things consuming the artifacts currently which don't expect the version to change from 1.0.0-SNAPSHOT. Until those are updated, this should not be bumping the version (in line with current Jenkins behaviour).