### PR TITLE
Fix issue updating GN3 spatial extent in talend component

### DIFF
--- a/iUpdateSpatialExtent/src/main/component/iUpdateSpatialExtent_begin.javajet
+++ b/iUpdateSpatialExtent/src/main/component/iUpdateSpatialExtent_begin.javajet
@@ -205,6 +205,7 @@ String harvestType = ElementParameterParser.getValue(node, "__HARVEST_TYPE__");
                 if(metadata_<%= cid %>.getRootElement().getNamespace().getURI().equals("http://standards.iso.org/iso/19115/-3/mdb/2.0")) {
                     org.jdom.Element surfaceMemberElement = new org.jdom.Element("surfaceMember", gmlNs).addContent((org.jdom.Element) polygon.clone());
                     org.jdom.Element multiSurfaceElement = new org.jdom.Element("MultiSurface", gmlNs).addContent(surfaceMemberElement);
+                    multiSurfaceElement.setAttribute("srsName", srsName_<%=cid%>);
                     polygonElement.addContent(multiSurfaceElement);
                 }
                 else {


### PR DESCRIPTION
Add srs for geometry to MultiSurface element (CRS84) so that corrdinates are correctly interpreted by GeoNetwork/geotools as lon/lat.

Sachit originally tested his changes prior to me fixing issues with SRS handling in GeoNewtork as a part of resolving Nat's high priority issues (editting/viewing bounding polygon's in GN3 was completely broken/non-existant).

