### PR TITLE
added try/catch in iUpdateSpatialExtent to prevent cascading failures

### DIFF
--- a/iUpdateSpatialExtent/src/main/component/iUpdateSpatialExtent_begin.javajet
+++ b/iUpdateSpatialExtent/src/main/component/iUpdateSpatialExtent_begin.javajet
@@ -238,7 +238,7 @@ String harvestType = ElementParameterParser.getValue(node, "__HARVEST_TYPE__");
         geonetworkClient_<%= cid %>.updateMetadata(<%= uuid %>, metadata_<%= cid %>.getRootElement());
 
         } catch (Exception e) {
-            System.out.format( "* iUpdateSpatialExtent - ERROR UPDATING SPATIAL EXTENT: cid=%s jobName=%s harvestType=%s uuid=%s exception=%s \n", <%= cid %>, <%= jobName %>, <%= jobName %>, <%= uuid %>, e.getMessage());
+            System.out.format( "* iUpdateSpatialExtent - ERROR UPDATING SPATIAL EXTENT: cid=%s jobName=%s harvestType=%s uuid=%s exception=%s \n", "<%= cid %>", <%= jobName %>, <%= harvestType %>, <%= uuid %>, e.getMessage());
             System.out.format( "* iUpdateSpatialExtent - stack trace to follow");
             e.printStackTrace();
         }

--- a/iUpdateSpatialExtent/src/main/component/iUpdateSpatialExtent_begin.javajet
+++ b/iUpdateSpatialExtent/src/main/component/iUpdateSpatialExtent_begin.javajet
@@ -103,6 +103,9 @@ String harvestType = ElementParameterParser.getValue(node, "__HARVEST_TYPE__");
 
     if(requireUpdate_<%=cid%>)
     {
+
+        try {
+
         String boundingPolygon_<%=cid%> = null;
 
         java.sql.Connection conn_<%=cid%> = null;
@@ -145,6 +148,7 @@ String harvestType = ElementParameterParser.getValue(node, "__HARVEST_TYPE__");
 
         // Connect to Geonetwork
 
+        System.out.format( "* iUpdateSpatialExtent - creating geonetwork client\n");
         it.geosolutions.geonetwork.GNClient geonetworkClient_<%= cid %> = new it.geosolutions.geonetwork.GNClient(
           <%= gnServiceUrl %>,
           <%= gnUsername %>,
@@ -153,6 +157,7 @@ String harvestType = ElementParameterParser.getValue(node, "__HARVEST_TYPE__");
 
         // Fetch specified metadata record
 
+        System.out.format( "* iUpdateSpatialExtent - getting metadata record: %s\n", <%= uuid %>);
         org.jdom.Document metadata_<%= cid %> = new org.jdom.Document(
             geonetworkClient_<%= cid %>.get(<%= uuid %>)
         );
@@ -229,5 +234,12 @@ String harvestType = ElementParameterParser.getValue(node, "__HARVEST_TYPE__");
 
         // Post updated record back to Geonetwork
 
+        System.out.format( "* iUpdateSpatialExtent - updating metadata: %s\n", <%= uuid %>);
         geonetworkClient_<%= cid %>.updateMetadata(<%= uuid %>, metadata_<%= cid %>.getRootElement());
+
+        } catch (Exception e) {
+            System.out.format( "* iUpdateSpatialExtent - ERROR UPDATING SPATIAL EXTENT: cid=%s jobName=%s harvestType=%s uuid=%s exception=%s \n", <%= cid %>, <%= jobName %>, <%= jobName %>, <%= uuid %>, e.getMessage());
+            System.out.format( "* iUpdateSpatialExtent - stack trace to follow");
+            e.printStackTrace();
+        }
     }


### PR DESCRIPTION
Backlog: https://github.com/aodn/backlog/issues/3882

- adds additional logging before calls made on the GNClient so that in case of an error it will be possible to know roughly where the issue was
- adds try/catch block with logging at the end with enough detail that if we decide to catch it with a sumo logic check
- note that I didn't indent the content of the try-block because indenting this would have made the diff almost unreadable and so I decided that it would be best to _not_ indent so that its easy to tell what this PR does.

in draft because I don't seem to be able to execute it in my talend studio right now because of some unrelated issue